### PR TITLE
set max_allowed_packet in my.cnf as a new variable

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -70,7 +70,7 @@ bind-address    = {{ percona_bind_address }}
 {% if percona_version | version_compare("5.6", "<=") %}
 key_buffer         = {{ percona_key_buffer }}
 {% endif %}
-max_allowed_packet = 16M
+max_allowed_packet = "{{ percona_max_allowed_packet | default('16M') }}" 
 thread_stack       = 192K
 thread_cache_size  = {{ percona_thread_cache_size }}
 # This replaces the startup script and checks MyISAM tables if needed


### PR DESCRIPTION
Passage du paramètre my.cnf « max_allowed_packet » en variable avec une valeur par défaut à 16M.